### PR TITLE
swap xml-simple for nori+nokogiri for parsing xml into a hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.3] - 2025-04-16
+### Changed
+- Drop Ox in order to revive Nokogiri usage so the gem can run on jruby.
+- Drop XmlSimple and replace with Nori
+
 ## [0.8.2] - 2021-12-21
 ### Fixed
 - Add support for Ruby 3.x.x.

--- a/cxml-ruby.gemspec
+++ b/cxml-ruby.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |s|
   s.email       = ['josh@officeluv.com', 'eleni@officeluv.com']
 
   s.required_ruby_version = '>= 2.4'
-  # s.add_dependency('ox', '~> 2.13')
   s.add_dependency('nokogiri', '~> 1.10')
-  s.add_dependency('xml-simple', '~> 1.1')
+  s.add_dependency('nori', '~> 2.6')
 
   s.add_development_dependency('pry-debugger-jruby')
   s.add_development_dependency('rake', '~> 13.0')

--- a/lib/cxml/document.rb
+++ b/lib/cxml/document.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require('nokogiri')
+
 module CXML
   class Document < DocumentNode
     attr_writer :dtd

--- a/lib/cxml/document_node.rb
+++ b/lib/cxml/document_node.rb
@@ -32,6 +32,11 @@ module CXML
     end
 
     def initialize(data = {})
+      if data.is_a?(Nori::StringWithAttributes)
+        @content = data
+        data.attributes.each { |arr| initialize_attribute(*arr) }
+        return
+      end
       if data.is_a?(String)
         @content = data
         return
@@ -88,6 +93,7 @@ module CXML
     def node_attributes
       self.class.attributes.each_with_object({}) do |attr, obj|
         value = send(attr)
+        value = content.attributes[attr] if value.nil? && content.is_a?(Nori::StringWithAttributes)
         value = value.iso8601 if value.is_a?(Time)
         next if value.respond_to?(:empty?) ? value.empty? : !value
 

--- a/lib/cxml/version.rb
+++ b/lib/cxml/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CXML
-  VERSION = '0.8.3'
+  VERSION = '0.8.4'
 end

--- a/spec/fixtures/punch_out_order_message_doc.xml
+++ b/spec/fixtures/punch_out_order_message_doc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-  <cxml version="1.2.020" payloadID="1346769469000.process.162998590@officedepot.com" timestamp="2012-09-04T02:37:49-05:00">
+  <cXML version="1.2.020" payloadID="1346769469000.process.162998590@officedepot.com" timestamp="2012-09-04T02:37:49-05:00">
     <Header>
         <From>
           <Credential domain="NetworkID">
@@ -29,4 +29,4 @@
         </PunchOutOrderMessageHeader>
       </PunchOutOrderMessage>
     </Message>
-  </cxml>
+  </cXML>


### PR DESCRIPTION
This commit swaps the xml-simple dependency for nori+nokogiri for xml parsing.  This also treats simple elements (elements with one child text node) as a Nori::StringWithAttributes so that parsing is more consistent